### PR TITLE
Performance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,8 @@ go 1.14
 
 require (
 	github.com/golang/protobuf v1.4.2
-	golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee
-	golang.org/x/net v0.0.0-20201010224723-4f7140c49acb
+	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de
+	golang.org/x/net v0.0.0-20200707034311-ab3426394381
+	golang.org/x/sys v0.0.0-20210104204734-6f8348627aad // indirect
 	google.golang.org/grpc v1.31.0
 )

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200124225646-8b5121be2f68/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee h1:4yd7jl+vXjalO5ztz6Vc1VADv+S/80LGJmyl1ROJ2AI=
 golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -95,6 +96,7 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201010224723-4f7140c49acb h1:mUVeFHoDKis5nxCAzoAi7E8Ghb86EXh/RK6wtvJIqRY=
 golang.org/x/net v0.0.0-20201010224723-4f7140c49acb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -105,8 +107,10 @@ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
-golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210104204734-6f8348627aad h1:MCsdmFSdEd4UEa5TKS5JztCRHK/WtvNei1edOj5RSRo=
+golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=


### PR DESCRIPTION
here some founding...
1. some pointer refreshed to 0 at beginning of func.
1. some re cal
1. some logic sample

local test result
old
BenchmarkSM2Sign-16                 3390            313408 ns/op            5426 B/op        117 allocs/op
BenchmarkSM2Sign-16                 3765            353670 ns/op            5428 B/op        117 allocs/op
BenchmarkSM2Sign-16                 3213            314760 ns/op            5448 B/op        117 allocs/op
BenchmarkSM2Sign-16                 4060            300734 ns/op            5402 B/op        117 allocs/op
BenchmarkSM2Sign-16                 3696            299816 ns/op            5431 B/op        117 allocs/op
BenchmarkSM2Verify-16                709           1637072 ns/op           78255 B/op       1602 allocs/op
BenchmarkSM2Verify-16                715           1646294 ns/op           81814 B/op       1675 allocs/op
BenchmarkSM2Verify-16                757           1653271 ns/op           78261 B/op       1617 allocs/op
BenchmarkSM2Verify-16                735           1693393 ns/op           76773 B/op       1588 allocs/op
BenchmarkSM2Verify-16                724           1634362 ns/op           79409 B/op       1643 allocs/op
BenchmarkEcdsaSign-16              49088             22950 ns/op            2639 B/op         32 allocs/op
BenchmarkEcdsaSign-16              51723             22920 ns/op            2639 B/op         32 allocs/op
BenchmarkEcdsaSign-16              52618             23115 ns/op            2638 B/op         32 allocs/op
BenchmarkEcdsaSign-16              52680             24454 ns/op            2639 B/op         32 allocs/op
BenchmarkEcdsaSign-16              44348             27033 ns/op            2639 B/op         32 allocs/op
BenchmarkEcdsaVerify-16            16728             67700 ns/op             825 B/op         16 allocs/op
BenchmarkEcdsaVerify-16            17436             68183 ns/op             830 B/op         16 allocs/op
BenchmarkEcdsaVerify-16            17846             68439 ns/op             825 B/op         16 allocs/op
BenchmarkEcdsaVerify-16            17810             68123 ns/op             825 B/op         16 allocs/op
BenchmarkEcdsaVerify-16            17280             69192 ns/op             825 B/op         16 allocs/op
PASS
ok      github.com/Hyperledger-TWGC/tjfoc-gm/sm2        30.208s

new
BenchmarkSM2Sign-16                 3735            289624 ns/op            5407 B/op        117 allocs/op
BenchmarkSM2Sign-16                 4045            277343 ns/op            5434 B/op        117 allocs/op
BenchmarkSM2Sign-16                 4028            274260 ns/op            5422 B/op        117 allocs/op
BenchmarkSM2Sign-16                 3774            277341 ns/op            5431 B/op        117 allocs/op
BenchmarkSM2Sign-16                 4213            279239 ns/op            5432 B/op        117 allocs/op
BenchmarkSM2Verify-16                775           1575745 ns/op           81951 B/op       1675 allocs/op
BenchmarkSM2Verify-16                788           1563233 ns/op           82487 B/op       1690 allocs/op
BenchmarkSM2Verify-16                717           1526143 ns/op           77000 B/op       1595 allocs/op
BenchmarkSM2Verify-16                750           1502272 ns/op           74926 B/op       1540 allocs/op
BenchmarkSM2Verify-16                782           1499108 ns/op           69170 B/op       1427 allocs/op
BenchmarkEcdsaSign-16              49248             23165 ns/op            2639 B/op         32 allocs/op
BenchmarkEcdsaSign-16              51198             23449 ns/op            2638 B/op         32 allocs/op
BenchmarkEcdsaSign-16              50770             23251 ns/op            2639 B/op         32 allocs/op
BenchmarkEcdsaSign-16              50355             23487 ns/op            2639 B/op         32 allocs/op
BenchmarkEcdsaSign-16              51072             23238 ns/op            2639 B/op         32 allocs/op
BenchmarkEcdsaVerify-16            16992             69044 ns/op             825 B/op         16 allocs/op
BenchmarkEcdsaVerify-16            17109             69145 ns/op             830 B/op         16 allocs/op
BenchmarkEcdsaVerify-16            16335             69115 ns/op             825 B/op         16 allocs/op
BenchmarkEcdsaVerify-16            16818             69884 ns/op             825 B/op         16 allocs/op
BenchmarkEcdsaVerify-16            17334             69036 ns/op             825 B/op         16 allocs/op
PASS
ok      github.com/Hyperledger-TWGC/tjfoc-gm/sm2        29.583s            826 B/op         16 allocs/op